### PR TITLE
Update draft-ietf-idr-bgp-sendholdtimer.xml

### DIFF
--- a/draft-ietf-idr-bgp-sendholdtimer.xml
+++ b/draft-ietf-idr-bgp-sendholdtimer.xml
@@ -231,7 +231,7 @@
 
   <section title="Changes to BGP Timers">
     <t>In Section 10 of <xref target="RFC4271"/> summarizes BGP Timers. This document adds another BGP timer: SendHoldTimer.</t>
-    <t>SendHoldTime is a mandatory FSM attribute that stores the initial value for the SendHoldTimer. SendHoldTime MUST be greater than the value of KeepaliveTime. The suggested default value for SendHoldTime is the greater of 8 minutes or 6 times KeepaliveTime. An implementation MAY make it configurable.</t>
+    <t>SendHoldTime is a mandatory FSM attribute that stores the initial value for the SendHoldTimer. SendHoldTime MUST be greater than the value of HoldTime. The suggested default value for SendHoldTime is the greater of 8 minutes or 2 times HoldTime. An implementation MAY make it configurable.</t>
   </section>
 
   </section>


### PR DESCRIPTION
The minimum of SendHoldTime needs to be bigger than HoldTime since you want that the regular HoldTimer fires before the SendHoldTime.

Also HoldTime is negotiated in OPEN while KeepAliveTime is only suggested to be 1/3 of HoldTime (but implementations can differ from that).